### PR TITLE
Added .bashrc setuping with ros2 autorun and colcon autocomplete

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,9 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 WORKDIR ${WS}
 
+RUN echo "if [ -f /opt/ros/\${ROS_DISTRO}/setup.bash ]; then source /opt/ros/\${ROS_DISTRO}/setup.bash; fi" >> /root/.bashrc && \
+    echo "if [ -f /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash ]; then source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash; fi" >> /root/.bashrc && \
+    echo "if [ -f ${WS}/install/setup.bash ]; then source ${WS}/install/setup.bash; fi" >> /root/.bashrc
 
 COPY docker/entrypoint.bash /entrypoint.bash
 RUN chmod +x /entrypoint.bash

--- a/docker/entrypoint.bash
+++ b/docker/entrypoint.bash
@@ -5,7 +5,7 @@ set -e
 source /opt/ros/${ROS_DISTRO}/setup.bash
 
 if [ -d /opt/ws/src ] && [ "$(ls -A  /opt/ws/src 2> /dev/null)" ]; then
-    if [ ! -f /opt/ws/install/setup.bash ] || [ /opt/ws/src -nt /opt/ws/install/setup.bash]; then
+    if [ ! -f /opt/ws/install/setup.bash ] || [ /opt/ws/src -nt /opt/ws/install/setup.bash ]; then
         echo "Building workspace..."
 
         rosdep install --from-paths src  --ignore-src -r -y || true


### PR DESCRIPTION
## Description
Automated the ROS 2 environment by appending core sourcing and colcon autocompletion to .bashrc for interactive sessions. Fixed possible bug in the entrypoint.bash.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Configuration change

## Changes Made
- added commands appending setup commands to the .bashrc on container creation
- bug fixed in the entrypoint.bash