### PR TITLE
Installation of the depthai driver for the OAK-D Pro camera added

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-joint-state-publisher-gui \
     ros-${ROS_DISTRO}-rviz2 \
     ros-${ROS_DISTRO}-rosbag2 \
+    ros-${ROS_DISTRO}-depthai-ros \
+    usbutils \
     libgl1 libglib2.0-0 \
     pkg-config \
     g++ make cmake \


### PR DESCRIPTION
## Description
Installation of the depthai driver for the OAK-D Pro camera and of the usbutils added to the Dockerfile

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Configuration change

## Changes Made

- commands installing the depthai driver and usbutils added to the `./docker/Dockerfile`  