### PR TITLE
Feature/navigation/perception pointcloud filter

### DIFF
--- a/src/indomitus_rover_perception/CMakeLists.txt
+++ b/src/indomitus_rover_perception/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.5)
+project(indomitus_rover_perception)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+#
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# Install Python scripts
+install(PROGRAMS scripts/pc_filter_node.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY launch config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/indomitus_rover_perception/config/filter_params.yaml
+++ b/src/indomitus_rover_perception/config/filter_params.yaml
@@ -1,0 +1,12 @@
+point_cloud_filter:
+  ros__parameters:
+    # Frame ID of the pointcloud
+    frame_id: "camera_depth_optical_frame"
+    
+    # Z-axis filtering bounds (meters)
+    min_z: 0.10
+    max_z: 1.50
+    
+    # Topic names
+    input_topic: "/camera/points"
+    output_topic: "/perception/obstacle_points"

--- a/src/indomitus_rover_perception/launch/filter.launch.py
+++ b/src/indomitus_rover_perception/launch/filter.launch.py
@@ -1,0 +1,21 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('indomitus_rover_perception'),
+        'config',
+        'filter_params.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='indomitus_rover_perception',
+            executable='pc_filter_node.py',
+            name='point_cloud_filter',
+            output='screen',
+            parameters=[config]
+        )
+    ])

--- a/src/indomitus_rover_perception/package.xml
+++ b/src/indomitus_rover_perception/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>indomitus_rover_perception</name>
+  <version>0.0.0</version>
+  <description>Perception module for Indomitus Rover</description>
+  <maintainer email="prokhorov.pn@ucu.edu.ua">Roman</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>sensor_msgs_py</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/indomitus_rover_perception/scripts/pc_filter_node.py
+++ b/src/indomitus_rover_perception/scripts/pc_filter_node.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import PointCloud2
+import sensor_msgs_py.point_cloud2 as pc2
+from sensor_msgs_py.point_cloud2 import create_cloud
+
+class PointCloudFilterNode(Node):
+    def __init__(self):
+        super().__init__('point_cloud_filter')
+        
+        # Declare parameters
+        self.declare_parameter('min_z', 0.1)
+        self.declare_parameter('max_z', 1.5)
+        self.declare_parameter('frame_id', 'camera_depth_optical_frame')
+        self.declare_parameter('input_topic', '/camera/points')
+        self.declare_parameter('output_topic', '/perception/obstacle_points')
+        
+        # Get parameters
+        self.min_z = self.get_parameter('min_z').value
+        self.max_z = self.get_parameter('max_z').value
+        self.target_frame = self.get_parameter('frame_id').value
+        input_topic = self.get_parameter('input_topic').value
+        output_topic = self.get_parameter('output_topic').value
+        
+        # Subscriptions and Publishers
+        self.subscription = self.create_subscription(PointCloud2, input_topic, self.pc_callback, 10)
+        self.publisher = self.create_publisher(PointCloud2, output_topic, 10)
+        
+        self.get_logger().info(f"Point Cloud Filter started.")
+
+    def pc_callback(self, msg):
+        # Read the point cloud into an iterable
+        cloud_data = list(pc2.read_points(msg, field_names=("x", "y", "z"), skip_nans=True))
+        
+        # Filter points based on the Z axis (height)
+        filtered_points = [
+            point for point in cloud_data 
+            if self.min_z <= point[2] <= self.max_z
+        ]
+        
+        # Create a new PointCloud2 message with the filtered points
+        header = msg.header
+        header.frame_id = self.target_frame
+        
+        filtered_msg = create_cloud(header, msg.fields, filtered_points)
+        
+        # Publish the filtered point cloud
+        self.publisher.publish(filtered_msg)
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = PointCloudFilterNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/src/indomitus_rover_perception/scripts/test_filter.py
+++ b/src/indomitus_rover_perception/scripts/test_filter.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import PointCloud2, PointField
+from std_msgs.msg import Header
+import sensor_msgs_py.point_cloud2 as pc2
+import struct
+import time
+import random
+
+class FilterTestNode(Node):
+    def __init__(self):
+        super().__init__('filter_test_node')
+        
+        self.publisher_ = self.create_publisher(PointCloud2, '/camera/points', 10)
+        self.subscriber_ = self.create_subscription(PointCloud2, '/perception/obstacle_points', self.listener_callback, 10)
+        
+        self.min_z = 0.10
+        self.max_z = 1.50
+        self.num_points = 50000
+        self.expected_count = 0
+        
+        self.timer = self.create_timer(1.0, self.publish_mock_cloud)
+
+    def generate_random_points(self, n):
+        points = []
+        valid_count = 0
+        for _ in range(n):
+            x = random.uniform(-5.0, 5.0)
+            y = random.uniform(-5.0, 5.0)
+            z = random.uniform(-0.5, 2.5)
+            points.append([x, y, z])
+            if self.min_z <= z <= self.max_z:
+                valid_count += 1
+        return points, valid_count
+        
+    def publish_mock_cloud(self):
+        points, self.expected_count = self.generate_random_points(self.num_points)
+        
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = 'camera_depth_optical_frame'
+        
+        cloud_msg = pc2.create_cloud_xyz32(header, points)
+        
+        self.get_logger().info(f'Publishing test point cloud with {self.num_points} points.')
+        self.publisher_.publish(cloud_msg)
+        
+    def listener_callback(self, msg):
+        cloud_data = list(pc2.read_points(msg, field_names=("x", "y", "z"), skip_nans=True))
+        
+        self.get_logger().info(f'Received filtered point cloud with {len(cloud_data)} points.')
+        
+        errors = 0
+        for p in cloud_data:
+            if not (self.min_z <= p[2] <= self.max_z):
+                errors += 1
+                
+        if errors == 0 and len(cloud_data) == self.expected_count:
+            self.get_logger().info('Validation passed: all points are within bounds and the count matches the expected value.')
+        else:
+            self.get_logger().error(f'Validation failed. Errors: {errors}. Expected count: {self.expected_count}, received: {len(cloud_data)}.')
+            
+        raise SystemExit
+
+def main(args=None):
+    rclpy.init(args=args)
+    test_node = FilterTestNode()
+    
+    try:
+        rclpy.spin(test_node)
+    except SystemExit:
+        pass
+    finally:
+        test_node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
Point cloud filtering system to the perception package. ROS 2 node that filters incoming `PointCloud2` messages based on Z-axis (height) limits.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
- [x] Configuration change

## Changes Made

- Created `scripts/pc_filter_node.py` to subscribe to raw point clouds and publish filtered point clouds using Z-axis bounds.
- Added `config/filter_params.yaml` to configure `min_z`, `max_z`, `frame_id`, and input/output topics.
- Added `launch/filter.launch.py` to launch the node with its parameter file.
- Added `scripts/test_filter.py`, test that generates random localized 3D points, publishes them, and mathematically validates the filter node's output against the expected bounds.

## Testing

- [x] I have tested this locally
- [x] All existing tests pass
- [x] I have added new tests 

### How to Test
1. Build: `colcon build --packages-select indomitus_rover_perception`
2. Source: `source install/setup.bash`
3. Launch node: `ros2 launch indomitus_rover_perception filter.launch.py`
4. Run test script (in new terminal): `./src/indomitus_rover_perception/scripts/test_filter.py`
5. Verify test outputs

## Additional Notes
- The node currently drops NaNs (`skip_nans=True`)
- Uses standard `sensor_msgs_py.point_cloud2` iterators instead of external libraries like PCL/NumPy