### PR TITLE
Hotfix: pr pipeline fixed to correctly handle image tags

### DIFF
--- a/.github/workflows/pr_pipeline.yaml
+++ b/.github/workflows/pr_pipeline.yaml
@@ -47,7 +47,17 @@ jobs:
           if [ "${{ steps.filter.outputs.docker }}" == "true" ]; then
             echo "tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ github.base_ref }}-dev" >> $GITHUB_OUTPUT
+            # Sanitize base_ref: replace slashes with hyphens
+            BASE_REF="${{ github.base_ref }}"
+            SAFE_BASE=$(echo "$BASE_REF" | sed 's/\//-/g')
+
+            # Only main and develop have published images.
+            # For any other base branch, fall back to develop-dev.
+            if [[ "$SAFE_BASE" == "main-dev" || "$SAFE_BASE" == "develop-dev" ]]; then
+              echo "tag=${SAFE_BASE}" >> $GITHUB_OUTPUT
+            else
+              echo "tag=develop-dev" >> $GITHUB_OUTPUT
+            fi
           fi
 
   build-temp-image:


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->

PR pipeline fixed to sanitize image tags and use only existing main-dev and develop-dev images for the fallback