### PR TITLE
hotfix: arm temporary added to the simulation packages in the dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 ARG UBUNTU_VERSION=22.04
 ARG ROS_DISTRO=humble
-ARG SIMULATION_PKGS="rover_sim rover_viz"
+
+# arm temporary added here to be ignored until the arm team fizes issue with the simulation and visualization dependencies
+ARG SIMULATION_PKGS="rover_sim rover_viz arm" 
 
 
 ####################


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->

This PR provides temporary fix for the build with `INSTALL_SIM_TOOLS=false` until the arm team fixes an issue with simulation and visualization dependencies.