### PR TITLE
chore: add arm_viz

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
 ARG UBUNTU_VERSION=22.04
 ARG ROS_DISTRO=humble
-
-# arm temporary added here to be ignored until the arm team fizes issue with the simulation and visualization dependencies
-ARG SIMULATION_PKGS="rover_sim rover_viz arm" 
+ARG SIMULATION_PKGS="rover_sim rover_viz arm_sim arm_viz" 
 
 
 ####################

--- a/src/arm/arm_bringup/launch/arm_standalone.launch.py
+++ b/src/arm/arm_bringup/launch/arm_standalone.launch.py
@@ -9,6 +9,7 @@ from launch_ros.parameter_descriptions import ParameterValue
 
 def generate_launch_description():
     arm_description_dir = get_package_share_directory('arm_description')
+    arm_viz_dir = get_package_share_directory('arm_viz')
     xacro_file = os.path.join(arm_description_dir, 'urdf', 'arm_standalone.urdf.xacro')
 
     use_fake_hardware_arg = DeclareLaunchArgument(
@@ -39,6 +40,6 @@ def generate_launch_description():
         Node(
             package='rviz2',
             executable='rviz2',
-            arguments=['-d', os.path.join(arm_description_dir, 'rviz', 'arm.rviz')]
+            arguments=['-d', os.path.join(arm_viz_dir, 'rviz', 'arm.rviz')]
         )
     ])

--- a/src/arm/arm_description/CMakeLists.txt
+++ b/src/arm/arm_description/CMakeLists.txt
@@ -14,7 +14,6 @@ install(
   DIRECTORY 
     urdf
     meshes
-    rviz
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/src/arm/arm_description/package.xml
+++ b/src/arm/arm_description/package.xml
@@ -20,8 +20,6 @@
   <exec_depend>ros2_control</exec_depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
-  <!-- <exec_depend>joint_state_publisher_gui</exec_depend> -->
-  <!-- <exec_depend>rviz2</exec_depend> -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/arm/arm_description/package.xml
+++ b/src/arm/arm_description/package.xml
@@ -20,8 +20,8 @@
   <exec_depend>ros2_control</exec_depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>joint_state_publisher_gui</exec_depend>
-  <exec_depend>rviz2</exec_depend>
+  <!-- <exec_depend>joint_state_publisher_gui</exec_depend> -->
+  <!-- <exec_depend>rviz2</exec_depend> -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/arm/arm_moveit_config/package.xml
+++ b/src/arm/arm_moveit_config/package.xml
@@ -23,12 +23,8 @@
   <exec_depend>moveit_planners</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
-  <!-- <exec_depend>joint_state_publisher_gui</exec_depend> -->
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <!-- The next 2 packages are required for the gazebo simulation.
-       We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>arm_description</exec_depend>
   <exec_depend>controller_manager</exec_depend>
@@ -38,9 +34,6 @@
   <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <!-- <exec_depend>rviz2</exec_depend> -->
-  <!-- <exec_depend>rviz_common</exec_depend> -->
-  <!-- <exec_depend>rviz_default_plugins</exec_depend> -->
   <exec_depend>tf2_ros</exec_depend>
 
 

--- a/src/arm/arm_moveit_config/package.xml
+++ b/src/arm/arm_moveit_config/package.xml
@@ -23,7 +23,7 @@
   <exec_depend>moveit_planners</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
-  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <!-- <exec_depend>joint_state_publisher_gui</exec_depend> -->
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
   <!-- The next 2 packages are required for the gazebo simulation.
@@ -38,9 +38,9 @@
   <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>rviz2</exec_depend>
-  <exec_depend>rviz_common</exec_depend>
-  <exec_depend>rviz_default_plugins</exec_depend>
+  <!-- <exec_depend>rviz2</exec_depend> -->
+  <!-- <exec_depend>rviz_common</exec_depend> -->
+  <!-- <exec_depend>rviz_default_plugins</exec_depend> -->
   <exec_depend>tf2_ros</exec_depend>
 
 

--- a/src/arm/arm_viz/CMakeLists.txt
+++ b/src/arm/arm_viz/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+project(arm_viz)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+install(
+  DIRECTORY rviz
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/arm/arm_viz/package.xml
+++ b/src/arm/arm_viz/package.xml
@@ -3,9 +3,13 @@
 <package format="3">
   <name>arm_viz</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="root@todo.todo">root</maintainer>
-  <license>TODO: License declaration</license>
+  <description>
+    Visualization package for the Indomitus 6-DOF robotic arm.
+    Provides RViz configurations and GUI tools for joint state monitoring 
+    specifically for the Arm sub-team.
+  </description>
+  <maintainer email="indomitus@ucu.edu.ua">UCUSpaceRobotics</maintainer>
+  <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/src/arm/arm_viz/package.xml
+++ b/src/arm/arm_viz/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>arm_viz</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="root@todo.todo">root</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>arm_description</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/arm/arm_viz/rviz/arm.rviz
+++ b/src/arm/arm_viz/rviz/arm.rviz
@@ -6,6 +6,7 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
+        - /RobotModel1
       Splitter Ratio: 0.5
     Tree Height: 555
   - Class: rviz_common/Selection
@@ -161,7 +162,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 10
+      Distance: 3.0787718296051025
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -176,10 +177,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.785398006439209
+      Pitch: 0.8903979659080505
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.785398006439209
+      Yaw: 0.44539809226989746
     Saved: ~
 Window Geometry:
   Displays:


### PR DESCRIPTION
## Description
This PR improves the project structure by decoupling visualization dependencies from core components. I have created a new arm_viz package for RViz configurations and removed redundant execution dependencies from arm_description and arm_moveit_config to ensure a lightweight and error-free build on the Jetson platform.