### PR TITLE
feat(arm): add gamepad teleop via ros2 joy game_controller_node

### DIFF
--- a/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
+++ b/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
@@ -41,8 +41,8 @@ Usage:
         ros2 run arm_tasks gamepad_servo_node
 
     ``gamepad_joy_driver`` is a thin wrapper around ``ros2 run joy
-    joy_node`` — see ``main_gamepad_joy_driver`` below for why this is
-    used instead of ``game_controller_node``.
+    joy_node``, kept as its own entry point so this launch command stays
+    stable regardless of what runs underneath it.
 """
 
 import os
@@ -482,6 +482,9 @@ class KeyboardInputLoop:
         self._exit_event = threading.Event()
         self._device = None
         self._read_thread = None
+        # Direction keys are ignored until Servo is running (see
+        # _read_loop) — pressing them earlier can't move the arm anyway.
+        self._servo_started = False
 
     def _open_device(self) -> bool:
         """Open the evdev keyboard device at ``self._device_path``.
@@ -554,6 +557,7 @@ class KeyboardInputLoop:
         if self._controller.move_to_safe_pose():
             print('Starting servo...')
             self._controller.start_servo()
+            self._servo_started = True
         else:
             print('Safe pose failed — Servo not started.')
 
@@ -588,6 +592,14 @@ class KeyboardInputLoop:
                     continue
 
                 if code not in self._DIRECTIONS:
+                    continue
+
+                # Direction keys are ignored entirely until Servo has
+                # started — _handle_safe_pose clears _pressed anyway, so
+                # tracking presses before that point would just be
+                # discarded, and set_velocity()'d twists Servo isn't
+                # listening to yet would have nothing to show for it.
+                if not self._servo_started:
                     continue
 
                 if value == self._KEYSTATE_DOWN:
@@ -670,26 +682,13 @@ class GamepadInputLoop:
     point) — as this module's docstring already promises,
     ``ServoController`` itself needs no changes.
 
-    ``joy_node`` (rather than ``game_controller_node``) is used
-    deliberately: ``game_controller_node`` goes through SDL, which maps
-    raw axes to named controls via a mapping database keyed by a GUID
-    derived from bus type + vendor + product + version. This
-    controller's Bluetooth GUID has no built-in entry, and SDL's
-    automatic fallback mapping for it is broken (confirmed live: it
-    never maps rightx/righty at all, and assigns lefttrigger/
-    righttrigger to the right stick's raw axes instead — the right
-    stick was completely dead). ``joy_node`` reads the kernel's
-    already-correctly-calibrated Linux joystick device directly, with
-    no SDL GUID lookup in between, sidestepping that whole class of bug.
-
     Axis/button indices and rest values below were established by
     watching `ros2 topic echo /joy` live with this controller over
-    Bluetooth through ``joy_node`` — not looked up from any mapping
-    database, since ``joy_node`` doesn't have one:
+    Bluetooth:
 
     * Axes 0/1 (left stick) and 2/3 (right stick) rest at 0.0, X left =
       +1.0, X right = -1.0, Y forward = +1.0, Y back = -1.0.
-    * Axes 4 (R2) and 5 (L2) rest at **+1.0** (released) and go to
+    * Axes 4 and 5 (L2 / R2) rest at **+1.0** (released) and go to
       **-1.0** at full press — the opposite convention from the sticks.
       ``_trigger_amount`` below converts that to the same "0 at rest"
       shape as everything else in this class expects.
@@ -700,14 +699,14 @@ class GamepadInputLoop:
     AXIS_LEFT_Y = 1     # pitch
     AXIS_RIGHT_X = 2    # left / right
     AXIS_RIGHT_Y = 3    # forward / back
-    AXIS_L2 = 4         # roll (normal) / down (Y held) — rests at +1.0, pressed -1.0
-    AXIS_R2 = 5         # roll (normal) / up (Y held)   — rests at +1.0, pressed -1.0
+    AXIS_L2 = 4         # roll (normal) / up (Y held)
+    AXIS_R2 = 5         # roll (normal) / down (Y held)
 
     BUTTON_SAFE_POSE = 0   # 'A' — move to safe pose + start servo
     BUTTON_Y = 3           # 'Y' — held to shift L2 / R2 from roll to up / down
     BUTTON_EXIT = 2        # 'X' — exit
 
-    _DEADZONE = 0.15
+    _DEADZONE = 0.2
     _JOY_TIMEOUT_SEC = 0.2
     _WATCHDOG_PERIOD_SEC = 0.1
 
@@ -727,13 +726,10 @@ class GamepadInputLoop:
         self._angular_speed = controller.angular_speed
         self._exit_event = threading.Event()
         # None means "no trustworthy baseline yet" — the first message
-        # after startup or after a /joy dropout is used only to seed
-        # this, never to fire a rising-edge action. Buttons can read
-        # garbage on that first message just like axes do (observed
-        # live: X came back as "pressed" on reconnect with nobody
-        # touching it, immediately exiting gamepad_servo_node instead
-        # of being ignored like a real accidental press would need a
-        # real prior "not pressed" reading to compare against).
+        # after startup or a /joy dropout only seeds this, it never
+        # fires a rising-edge action (a gamepad can report a stale
+        # "pressed" button on that first message, which was causing
+        # spurious exits).
         self._prev_buttons = None
         self._shift_armed = {self.BUTTON_Y: False}
         self._safe_pose_running = threading.Lock()
@@ -751,19 +747,14 @@ class GamepadInputLoop:
         self._joy_silent = False
         self._teleop_locked = True
 
-        # A dropout (watchdog timeout below) does NOT re-lock teleop,
-        # but it does set this: the first /joy message(s) after a
-        # dropout are known-unreliable in practice (observed live: the
-        # left stick reporting full deflection for several messages
-        # right after "/joy resumed", with nothing touched) — likely
-        # SDL's controller state not having settled yet right after
-        # re-opening the device. So instead of acting on them, we force
-        # zero velocity and wait, with no timeout, until one message
-        # reports every monitored axis centered — then resume normally
-        # from wherever the arm already is. No button, no safe pose;
-        # on a healthy connection this clears within a message or two
-        # and is invisible. If it never clears, that's a genuinely bad
-        # connection and the arm staying stopped is the correct outcome.
+        # A dropout does not re-lock teleop, but it does set this: the
+        # first /joy message(s) after a dropout can report stale values
+        # (observed live: full deflection with nothing touched) — likely
+        # a freshly re-created Bluetooth HID device reporting a default
+        # before its first real report arrives. So we force zero
+        # velocity and wait, with no timeout, until one message reports
+        # everything centered/released, then resume from wherever the
+        # arm already is.
         self._joy_settling = False
 
         self._sub = controller.create_subscription(Joy, 'joy', self._on_joy, 10)
@@ -857,7 +848,7 @@ class GamepadInputLoop:
         """Stop the arm if no ``/joy`` message has arrived recently.
 
         Runs on the node's own timer, independent of message arrival, so
-        a disconnected controller or a dead ``game_controller_node`` can't
+        a disconnected controller or a dead ``joy_node`` can't
         leave the last commanded velocity republishing forever — Servo's
         own command timeout does not help here because ServoController
         keeps re-publishing that last twist every tick regardless of
@@ -956,11 +947,8 @@ class GamepadInputLoop:
         ``start_servo()`` re-enables Servo, before the operator has a
         chance to let go.
 
-        This is also the *only* place ``_teleop_locked`` is cleared. It's
-        a one-time latch: once cleared, a later ``/joy`` dropout does not
-        set it again (see ``_check_joy_timeout``), so control resumes
-        from wherever the arm already is on reconnect, with no repeat
-        trip back to the fixed safe pose.
+        This is also the only place ``_teleop_locked`` is cleared (see
+        its declaration in ``__init__``).
         """
         if not self._safe_pose_running.acquire(blocking=False):
             return
@@ -1029,9 +1017,8 @@ def main_gamepad():
     """Entry point: initialize ROS2, run the gamepad input loop, and clean up.
 
     Requires a running ``joy`` publisher — use ``gamepad_joy_driver``
-    (below), not a plain ``ros2 run joy game_controller_node``, or the
-    Bluetooth axis mapping fix won't be applied. See ``_run_teleop`` for
-    the shared spin/cleanup lifecycle.
+    (below) to start it. See ``_run_teleop`` for the shared spin/cleanup
+    lifecycle.
     """
     rclpy.init()
     controller = ServoController()
@@ -1039,33 +1026,20 @@ def main_gamepad():
 
 
 def main_gamepad_joy_driver():
-    """Entry point: run ``joy``'s ``joy_node`` (not ``game_controller_node``).
+    """Entry point: run ``joy``'s ``joy_node``.
 
-    ``game_controller_node`` goes through SDL's GameController
-    abstraction, which maps raw axes/buttons to named controls
-    (leftx, righttrigger, ...) via a lookup keyed by a GUID derived
-    from bus type + vendor + product + version. Over Bluetooth this
-    controller has no matching built-in SDL mapping (its Bluetooth
-    GUID differs from its USB one), and SDL's automatic fallback
-    mapping for it is broken: confirmed live that it never maps
-    rightx/righty at all, and instead assigns lefttrigger/righttrigger
-    to the right stick's raw axes.
-
-    ``joy_node`` instead reads the kernel's already-calibrated Linux
-    joystick device directly (``/dev/input/jsN``), with no SDL GUID
-    lookup or guessed mapping in between — so this whole class of bug
-    doesn't apply to it. Axis/button indices are hardware-order, fixed
-    once via `ros2 topic echo /joy` while testing this controller (see
-    ``GamepadInputLoop``'s docstring), not looked up from any database.
+    ``joy_node`` reads the kernel's already-calibrated Linux joystick
+    device directly (``/dev/input/jsN``). Axis/button indices are
+    hardware-order, fixed once via `ros2 topic echo /joy` while testing
+    this controller (see ``GamepadInputLoop``'s docstring).
 
     A drop-in replacement for ``ros2 run joy joy_node``, kept as its
     own entry point (rather than telling the operator to just run that
-    directly) so the launch command stays the same regardless of which
-    underlying driver this class ends up needing. Uses ``os.execvp``
-    rather than a subprocess so this process directly becomes
-    ``joy_node`` — signals (e.g. Ctrl+C) and process lifetime behave
-    exactly as if it had been started directly, with no extra wrapper
-    process left in between.
+    directly) so the launch command stays stable regardless of what
+    runs underneath it. Uses ``os.execvp`` rather than a subprocess so
+    this process directly becomes ``joy_node`` — signals (e.g. Ctrl+C)
+    and process lifetime behave exactly as if it had been started
+    directly, with no extra wrapper process left in between.
     """
     os.execvp('ros2', ['ros2', 'run', 'joy', 'joy_node'])
 

--- a/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
+++ b/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
@@ -652,6 +652,14 @@ GAMEPAD_HELP = """
 ║  L2 / R2, Y held  — up / down      (Z)       ║
 ║  A                — safe pose + servo        ║
 ║  X                — exit                     ║
+╠══════════════════════════════════════════════╣
+║  Press A once at startup: sticks/triggers    ║
+║  are ignored until the safe-pose move        ║
+║  succeeds. After that, a /joy dropout (e.g.  ║
+║  Bluetooth reconnect) just pauses motion,    ║
+║  then auto-resumes from the current position ║
+║  as soon as a clean centered reading comes   ║
+║  in — no button, no trip back to safe pose.  ║
 ╚══════════════════════════════════════════════╝
 """
 
@@ -664,29 +672,37 @@ class GamepadInputLoop:
     ``ros2 run joy game_controller_node``) — as this module's docstring
     already promises, ``ServoController`` itself needs no changes.
 
-    Axis/button indices follow the standard SDL_GameController enum,
-    which ros2 joy's game_controller_node wraps directly — axes in the
-    order LEFTX, LEFTY, RIGHTX, RIGHTY, TRIGGERLEFT, TRIGGERRIGHT, and
-    buttons A, B, X, Y, BACK, GUIDE, START, LEFTSTICK, RIGHTSTICK, ...
-    This matches a live baseline read from a Stadia controller (6 axes,
-    20 buttons, all resting at 0), and axis 1 = left-stick-Y was
-    confirmed directly against hardware. The rest follow from the same
-    enum and are very likely correct, but confirm anything that doesn't
-    respond as expected via `ros2 topic echo /joy`.
+    Axis/button indices match SDL2's built-in mapping for this exact
+    controller (GUID 03000000d11800000094000011010000, name "Google
+    Stadia Controller" — confirmed by dumping strings from
+    libSDL2-2.0.so.0: "leftx:a0,lefty:a1,rightx:a2,righty:a3,
+    righttrigger:a4,lefttrigger:a5,a:b0,x:b2,y:b3,..."), which only
+    applies when game_controller_node opens the device under that
+    identity. Over Bluetooth this controller has also been observed
+    reconnecting under an unmapped raw name ("StadiaBFRY-fe89") that
+    does NOT get this mapping and produces unusable/garbage axis data
+    — that is a pairing problem to fix at the OS level (re-pair the
+    device), not something these indices can compensate for. A wired
+    USB connection reliably opens under the mapped identity and was
+    used to confirm this exact axis order live via `ros2 topic echo
+    /joy`, including that L2/R2 are TRIGGERLEFT/TRIGGERRIGHT — i.e.
+    swapped relative to a naive "L2 first" numbering.
     """
 
     AXIS_LEFT_X = 0     # yaw
     AXIS_LEFT_Y = 1     # pitch
     AXIS_RIGHT_X = 2    # left / right
     AXIS_RIGHT_Y = 3    # forward / back
-    AXIS_L2 = 4         # roll (normal) / down (Y held) — negative half of the pair
-    AXIS_R2 = 5         # roll (normal) / up (Y held)   — positive half of the pair
+    AXIS_R2 = 4         # roll (normal) / down (Y held) — negative half of the pair
+    AXIS_L2 = 5         # roll (normal) / up (Y held)   — positive half of the pair
 
     BUTTON_SAFE_POSE = 0   # 'A' — move to safe pose + start servo
     BUTTON_Y = 3           # 'Y' — held to shift L2 / R2 from roll to up / down
     BUTTON_EXIT = 2        # 'X' — exit
 
     _DEADZONE = 0.15
+    _JOY_TIMEOUT_SEC = 0.2
+    _WATCHDOG_PERIOD_SEC = 0.1
 
     def __init__(self, controller: 'ServoController'):
         """Store a reference to the controller and subscribe to ``/joy``.
@@ -706,8 +722,39 @@ class GamepadInputLoop:
         self._prev_buttons = []
         self._shift_armed = {self.BUTTON_Y: False}
         self._safe_pose_running = threading.Lock()
+        self._safe_pose_active = False
         self._prev_active = (False,) * 6
+
+        # Teleop (axes -> velocity) is locked out until the first
+        # safe-pose move (A) completes — Servo hasn't been started yet
+        # at that point, so nothing would move anyway, and the arm's
+        # real-world pose is unknown to this process until then. This
+        # is a one-time latch: once armed it stays armed, including
+        # across /joy dropouts (e.g. a Bluetooth reconnect) — there is
+        # no re-arm button and no trip back to the fixed safe pose.
+        self._last_joy_time = None
+        self._joy_silent = False
+        self._teleop_locked = True
+
+        # A dropout (watchdog timeout below) does NOT re-lock teleop,
+        # but it does set this: the first /joy message(s) after a
+        # dropout are known-unreliable in practice (observed live: the
+        # left stick reporting full deflection for several messages
+        # right after "/joy resumed", with nothing touched) — likely
+        # SDL's controller state not having settled yet right after
+        # re-opening the device. So instead of acting on them, we force
+        # zero velocity and wait, with no timeout, until one message
+        # reports every monitored axis centered — then resume normally
+        # from wherever the arm already is. No button, no safe pose;
+        # on a healthy connection this clears within a message or two
+        # and is invisible. If it never clears, that's a genuinely bad
+        # connection and the arm staying stopped is the correct outcome.
+        self._joy_settling = False
+
         self._sub = controller.create_subscription(Joy, 'joy', self._on_joy, 10)
+        self._watchdog_timer = controller.create_timer(
+            self._WATCHDOG_PERIOD_SEC, self._check_joy_timeout
+        )
 
     @classmethod
     def _deadzone(cls, value: float) -> float:
@@ -769,10 +816,71 @@ class GamepadInputLoop:
             parts.append('Y+L2/R2')
         return '+'.join(parts) if parts else ('Y' if y_held else 'idle')
 
+    def _check_joy_timeout(self):
+        """Stop the arm if no ``/joy`` message has arrived recently.
+
+        Runs on the node's own timer, independent of message arrival, so
+        a disconnected controller or a dead ``game_controller_node`` can't
+        leave the last commanded velocity republishing forever — Servo's
+        own command timeout does not help here because ServoController
+        keeps re-publishing that last twist every tick regardless of
+        whether new input has arrived. This only zeroes the current
+        command; it does not lock teleop out, so control resumes on its
+        own the moment ``/joy`` messages start arriving again (e.g. a
+        Bluetooth reconnect) — no separate re-arm step.
+        """
+        if self._last_joy_time is None:
+            return
+        elapsed = (self._controller.get_clock().now() - self._last_joy_time).nanoseconds / 1e9
+        if elapsed > self._JOY_TIMEOUT_SEC:
+            if not self._joy_silent:
+                self._joy_silent = True
+                self._joy_settling = True
+                self._controller.get_logger().warn(
+                    f'/joy timed out after {elapsed:.2f}s — stopping arm.'
+                )
+            self._controller.stop()
+
     def _on_joy(self, msg: Joy):
         """Translate one Joy snapshot into a velocity command and edge-triggered actions."""
         axes = msg.axes
         buttons = msg.buttons
+
+        if self._joy_silent:
+            self._joy_silent = False
+            self._controller.get_logger().info('/joy resumed.')
+        self._last_joy_time = self._controller.get_clock().now()
+
+        # Button edges are always processed, even while teleop is locked
+        # out — buttons are digital (no analog drift), and the safe-pose
+        # button is the only way to clear the lock, so it must keep
+        # working while locked or the arm could never be armed at all.
+        safe_pose_pressed = self._button_rising_edge(buttons, self.BUTTON_SAFE_POSE)
+        exit_pressed = self._button_rising_edge(buttons, self.BUTTON_EXIT)
+        self._prev_buttons = list(buttons)
+
+        if exit_pressed:
+            self._exit_event.set()
+
+        if safe_pose_pressed:
+            threading.Thread(target=self._handle_safe_pose, daemon=True).start()
+
+        if self._teleop_locked or self._safe_pose_active:
+            self._controller.stop()
+            return
+
+        if self._joy_settling:
+            centered = all(
+                self._axis(axes, i) == 0.0
+                for i in (self.AXIS_LEFT_X, self.AXIS_LEFT_Y,
+                          self.AXIS_RIGHT_X, self.AXIS_RIGHT_Y,
+                          self.AXIS_L2, self.AXIS_R2)
+            )
+            self._controller.stop()
+            if centered:
+                self._joy_settling = False
+                self._controller.get_logger().info('Sticks centered — resuming control.')
+            return
 
         vy = self._axis(axes, self.AXIS_RIGHT_X) * self._linear_speed
         vx = self._axis(axes, self.AXIS_RIGHT_Y) * self._linear_speed
@@ -795,32 +903,39 @@ class GamepadInputLoop:
                   f'wx={wx:.2f} wy={wy:.2f} wz={wz:.2f}')
         self._prev_active = active
 
-        if self._button_rising_edge(buttons, self.BUTTON_SAFE_POSE):
-            threading.Thread(target=self._handle_safe_pose, daemon=True).start()
-
-        if self._button_rising_edge(buttons, self.BUTTON_EXIT):
-            self._exit_event.set()
-
-        self._prev_buttons = list(buttons)
-
     def _handle_safe_pose(self):
         """Stop motion and move to the safe pose (mirrors KeyboardInputLoop's 'r').
 
         Guarded by a non-blocking lock so a second button press while a
         move is already in progress is ignored instead of racing a
-        redundant safe-pose goal against the first.
+        redundant safe-pose goal against the first. Also sets
+        ``_safe_pose_active`` for the duration so ``_on_joy`` ignores
+        stick/trigger input while it's set — otherwise a stick held
+        during the move would resume Cartesian motion the instant
+        ``start_servo()`` re-enables Servo, before the operator has a
+        chance to let go.
+
+        This is also the *only* place ``_teleop_locked`` is cleared. It's
+        a one-time latch: once cleared, a later ``/joy`` dropout does not
+        set it again (see ``_check_joy_timeout``), so control resumes
+        from wherever the arm already is on reconnect, with no repeat
+        trip back to the fixed safe pose.
         """
         if not self._safe_pose_running.acquire(blocking=False):
             return
+        self._safe_pose_active = True
         try:
             self._controller.stop()
             print('Moving to safe pose...')
             if self._controller.move_to_safe_pose():
                 print('Starting servo...')
                 self._controller.start_servo()
+                self._teleop_locked = False
+                self._controller.get_logger().info('Teleop enabled.')
             else:
                 print('Safe pose failed — Servo not started.')
         finally:
+            self._safe_pose_active = False
             self._safe_pose_running.release()
 
     def run(self):

--- a/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
+++ b/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
@@ -20,7 +20,7 @@ Controls:
     r      — move to safe pose + start servo
     ESC/x  — exit
 
-Gamepad controls (via ros2 joy game_controller_node, e.g. Stadia controller):
+Gamepad controls (via ros2 joy joy_node, e.g. Stadia controller):
     Right stick      — forward/back, left/right  (X / Y axis)
     Left stick       — yaw / pitch
     L2 / R2          — roll
@@ -41,9 +41,8 @@ Usage:
         ros2 run arm_tasks gamepad_servo_node
 
     ``gamepad_joy_driver`` is a thin wrapper around ``ros2 run joy
-    game_controller_node`` — see ``main_gamepad_joy_driver`` below for
-    why a plain ``ros2 run joy game_controller_node`` isn't enough for
-    this specific controller over Bluetooth.
+    joy_node`` — see ``main_gamepad_joy_driver`` below for why this is
+    used instead of ``game_controller_node``.
 """
 
 import os
@@ -66,29 +65,6 @@ from builtin_interfaces.msg import Duration
 import evdev
 from evdev import ecodes
 
-
-# SDL's built-in mapping for this controller (GUID
-# 03000000d11800000094000011010000, name "Google Stadia Controller") only
-# matches it over USB. Over Bluetooth the same physical controller gets a
-# different GUID (05000000d11800000094000000010000 — same vendor/product,
-# different bus-type byte), which has no built-in entry, and SDL's
-# automatic fallback mapping for it is broken: confirmed live via a
-# standalone SDL2 test program dumping SDL_GameControllerMapping() that it
-# never maps rightx/righty at all, and instead assigns lefttrigger and
-# righttrigger to the right stick's raw axes (a2/a3). This override is
-# that same auto-generated mapping, corrected: rightx/righty restored on
-# their real raw axes, and the triggers moved to their real raw axes
-# (a4/a5, confirmed via `ros2 topic echo /joy` and raw evdev ABS values).
-# Harmless over USB, where the built-in mapping already wins for its own
-# (different) GUID.
-STADIA_BLUETOOTH_MAPPING = (
-    "05000000d11800000094000000010000,StadiaBFRY-fe89,"
-    "a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,"
-    "leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,"
-    "dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,"
-    "leftx:a0,lefty:a1,rightx:a2,righty:a3,"
-    "lefttrigger:a4,righttrigger:a5,platform:Linux"
-)
 
 DEFAULT_LINEAR_SPEED  = 0.1
 DEFAULT_ANGULAR_SPEED = 0.3
@@ -690,32 +666,42 @@ class GamepadInputLoop:
 
     Replaces the raw-keyboard evdev input of ``KeyboardInputLoop`` with a
     subscription to the ``joy`` package's ``/joy`` topic (published by
-    ``ros2 run joy game_controller_node``) — as this module's docstring
-    already promises, ``ServoController`` itself needs no changes.
+    ``ros2 run joy joy_node``, via the ``gamepad_joy_driver`` entry
+    point) — as this module's docstring already promises,
+    ``ServoController`` itself needs no changes.
 
-    Axis/button indices match SDL2's built-in mapping for this exact
-    controller (GUID 03000000d11800000094000011010000, name "Google
-    Stadia Controller" — confirmed by dumping strings from
-    libSDL2-2.0.so.0: "leftx:a0,lefty:a1,rightx:a2,righty:a3,
-    righttrigger:a4,lefttrigger:a5,a:b0,x:b2,y:b3,..."), which only
-    applies when game_controller_node opens the device under that
-    identity. Over Bluetooth this controller has also been observed
-    reconnecting under an unmapped raw name ("StadiaBFRY-fe89") that
-    does NOT get this mapping and produces unusable/garbage axis data
-    — that is a pairing problem to fix at the OS level (re-pair the
-    device), not something these indices can compensate for. A wired
-    USB connection reliably opens under the mapped identity and was
-    used to confirm this exact axis order live via `ros2 topic echo
-    /joy`, including that L2/R2 are TRIGGERLEFT/TRIGGERRIGHT — i.e.
-    swapped relative to a naive "L2 first" numbering.
+    ``joy_node`` (rather than ``game_controller_node``) is used
+    deliberately: ``game_controller_node`` goes through SDL, which maps
+    raw axes to named controls via a mapping database keyed by a GUID
+    derived from bus type + vendor + product + version. This
+    controller's Bluetooth GUID has no built-in entry, and SDL's
+    automatic fallback mapping for it is broken (confirmed live: it
+    never maps rightx/righty at all, and assigns lefttrigger/
+    righttrigger to the right stick's raw axes instead — the right
+    stick was completely dead). ``joy_node`` reads the kernel's
+    already-correctly-calibrated Linux joystick device directly, with
+    no SDL GUID lookup in between, sidestepping that whole class of bug.
+
+    Axis/button indices and rest values below were established by
+    watching `ros2 topic echo /joy` live with this controller over
+    Bluetooth through ``joy_node`` — not looked up from any mapping
+    database, since ``joy_node`` doesn't have one:
+
+    * Axes 0/1 (left stick) and 2/3 (right stick) rest at 0.0, X left =
+      +1.0, X right = -1.0, Y forward = +1.0, Y back = -1.0.
+    * Axes 4 (R2) and 5 (L2) rest at **+1.0** (released) and go to
+      **-1.0** at full press — the opposite convention from the sticks.
+      ``_trigger_amount`` below converts that to the same "0 at rest"
+      shape as everything else in this class expects.
+    * Buttons 0/2/3 are A/X/Y.
     """
 
     AXIS_LEFT_X = 0     # yaw
     AXIS_LEFT_Y = 1     # pitch
     AXIS_RIGHT_X = 2    # left / right
     AXIS_RIGHT_Y = 3    # forward / back
-    AXIS_R2 = 4         # roll (normal) / down (Y held) — negative half of the pair
-    AXIS_L2 = 5         # roll (normal) / up (Y held)   — positive half of the pair
+    AXIS_L2 = 4         # roll (normal) / down (Y held) — rests at +1.0, pressed -1.0
+    AXIS_R2 = 5         # roll (normal) / up (Y held)   — rests at +1.0, pressed -1.0
 
     BUTTON_SAFE_POSE = 0   # 'A' — move to safe pose + start servo
     BUTTON_Y = 3           # 'Y' — held to shift L2 / R2 from roll to up / down
@@ -795,6 +781,21 @@ class GamepadInputLoop:
         if index >= len(axes):
             return 0.0
         return self._deadzone(axes[index])
+
+    def _trigger_amount(self, axes, index: int) -> float:
+        """Return how far a trigger (L2/R2) is pressed: 0.0 (released) .. 1.0 (full press).
+
+        ``joy_node`` reports these axes resting at +1.0 and going to
+        -1.0 at full press — inverted and offset from every other axis
+        in this class, which rests at 0.0. Remapping it here means the
+        deadzone, the settle-guard's "must be centered" check, and
+        ``_route``'s arming logic can all keep treating 0.0 as "at
+        rest" uniformly, without special-casing these two axes.
+        """
+        if index >= len(axes):
+            return 0.0
+        amount = (1.0 - axes[index]) / 2.0
+        return 0.0 if amount < self._DEADZONE else amount
 
     def _button_pressed(self, buttons, index: int) -> bool:
         """Return True if ``buttons[index]`` is currently held down."""
@@ -907,11 +908,14 @@ class GamepadInputLoop:
             return
 
         if self._joy_settling:
-            centered = all(
-                self._axis(axes, i) == 0.0
-                for i in (self.AXIS_LEFT_X, self.AXIS_LEFT_Y,
-                          self.AXIS_RIGHT_X, self.AXIS_RIGHT_Y,
-                          self.AXIS_L2, self.AXIS_R2)
+            centered = (
+                all(
+                    self._axis(axes, i) == 0.0
+                    for i in (self.AXIS_LEFT_X, self.AXIS_LEFT_Y,
+                              self.AXIS_RIGHT_X, self.AXIS_RIGHT_Y)
+                )
+                and self._trigger_amount(axes, self.AXIS_L2) == 0.0
+                and self._trigger_amount(axes, self.AXIS_R2) == 0.0
             )
             self._controller.stop()
             if centered:
@@ -925,7 +929,7 @@ class GamepadInputLoop:
         wz = self._axis(axes, self.AXIS_LEFT_X) * self._angular_speed
         wy = self._axis(axes, self.AXIS_LEFT_Y) * self._angular_speed
 
-        trigger_diff = self._axis(axes, self.AXIS_R2) - self._axis(axes, self.AXIS_L2)
+        trigger_diff = self._trigger_amount(axes, self.AXIS_R2) - self._trigger_amount(axes, self.AXIS_L2)
         y_held = self._button_pressed(buttons, self.BUTTON_Y)
         roll, updown = self._route(self.BUTTON_Y, y_held, trigger_diff)
         wx = roll * self._angular_speed
@@ -1035,23 +1039,35 @@ def main_gamepad():
 
 
 def main_gamepad_joy_driver():
-    """Entry point: run ``joy``'s ``game_controller_node`` with a fixed
-    Bluetooth mapping for the Stadia controller.
+    """Entry point: run ``joy``'s ``joy_node`` (not ``game_controller_node``).
 
-    A drop-in replacement for ``ros2 run joy game_controller_node`` —
-    sets ``SDL_GAMECONTROLLERCONFIG`` (see ``STADIA_BLUETOOTH_MAPPING``)
-    before exec'ing the real node, so the override is always in effect
-    without the operator having to remember to export it by hand each
-    time (it only lives for the lifetime of the process it's exported
-    into, so a plain ``ros2 run joy game_controller_node`` picks up
-    SDL's broken auto-generated Bluetooth mapping again every time).
-    Uses ``os.execvp`` rather than a subprocess so this process directly
-    becomes ``game_controller_node`` — signals (e.g. Ctrl+C) and process
-    lifetime behave exactly as if it had been started directly, with no
-    extra wrapper process left in between.
+    ``game_controller_node`` goes through SDL's GameController
+    abstraction, which maps raw axes/buttons to named controls
+    (leftx, righttrigger, ...) via a lookup keyed by a GUID derived
+    from bus type + vendor + product + version. Over Bluetooth this
+    controller has no matching built-in SDL mapping (its Bluetooth
+    GUID differs from its USB one), and SDL's automatic fallback
+    mapping for it is broken: confirmed live that it never maps
+    rightx/righty at all, and instead assigns lefttrigger/righttrigger
+    to the right stick's raw axes.
+
+    ``joy_node`` instead reads the kernel's already-calibrated Linux
+    joystick device directly (``/dev/input/jsN``), with no SDL GUID
+    lookup or guessed mapping in between — so this whole class of bug
+    doesn't apply to it. Axis/button indices are hardware-order, fixed
+    once via `ros2 topic echo /joy` while testing this controller (see
+    ``GamepadInputLoop``'s docstring), not looked up from any database.
+
+    A drop-in replacement for ``ros2 run joy joy_node``, kept as its
+    own entry point (rather than telling the operator to just run that
+    directly) so the launch command stays the same regardless of which
+    underlying driver this class ends up needing. Uses ``os.execvp``
+    rather than a subprocess so this process directly becomes
+    ``joy_node`` — signals (e.g. Ctrl+C) and process lifetime behave
+    exactly as if it had been started directly, with no extra wrapper
+    process left in between.
     """
-    os.environ['SDL_GAMECONTROLLERCONFIG'] = STADIA_BLUETOOTH_MAPPING
-    os.execvp('ros2', ['ros2', 'run', 'joy', 'game_controller_node'])
+    os.execvp('ros2', ['ros2', 'run', 'joy', 'joy_node'])
 
 
 if __name__ == '__main__':

--- a/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
+++ b/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
@@ -37,15 +37,10 @@ Usage:
             --params-file $(ros2 pkg prefix arm_sim)/share/arm_sim/config/keyboard_servo_sim.yaml
 
     Gamepad, any target (start the joystick driver first, then this node):
-        ros2 run arm_tasks gamepad_joy_driver
+        ros2 run joy joy_node
         ros2 run arm_tasks gamepad_servo_node
-
-    ``gamepad_joy_driver`` is a thin wrapper around ``ros2 run joy
-    joy_node``, kept as its own entry point so this launch command stays
-    stable regardless of what runs underneath it.
 """
 
-import os
 import sys
 import threading
 import termios
@@ -678,9 +673,8 @@ class GamepadInputLoop:
 
     Replaces the raw-keyboard evdev input of ``KeyboardInputLoop`` with a
     subscription to the ``joy`` package's ``/joy`` topic (published by
-    ``ros2 run joy joy_node``, via the ``gamepad_joy_driver`` entry
-    point) — as this module's docstring already promises,
-    ``ServoController`` itself needs no changes.
+    ``ros2 run joy joy_node``) — as this module's docstring already
+    promises, ``ServoController`` itself needs no changes.
 
     Axis/button indices and rest values below were established by
     watching `ros2 topic echo /joy` live with this controller over
@@ -1016,32 +1010,12 @@ def main():
 def main_gamepad():
     """Entry point: initialize ROS2, run the gamepad input loop, and clean up.
 
-    Requires a running ``joy`` publisher — use ``gamepad_joy_driver``
-    (below) to start it. See ``_run_teleop`` for the shared spin/cleanup
-    lifecycle.
+    Requires a running ``joy`` publisher (``ros2 run joy joy_node``).
+    See ``_run_teleop`` for the shared spin/cleanup lifecycle.
     """
     rclpy.init()
     controller = ServoController()
     _run_teleop(controller, GamepadInputLoop(controller))
-
-
-def main_gamepad_joy_driver():
-    """Entry point: run ``joy``'s ``joy_node``.
-
-    ``joy_node`` reads the kernel's already-calibrated Linux joystick
-    device directly (``/dev/input/jsN``). Axis/button indices are
-    hardware-order, fixed once via `ros2 topic echo /joy` while testing
-    this controller (see ``GamepadInputLoop``'s docstring).
-
-    A drop-in replacement for ``ros2 run joy joy_node``, kept as its
-    own entry point (rather than telling the operator to just run that
-    directly) so the launch command stays stable regardless of what
-    runs underneath it. Uses ``os.execvp`` rather than a subprocess so
-    this process directly becomes ``joy_node`` — signals (e.g. Ctrl+C)
-    and process lifetime behave exactly as if it had been started
-    directly, with no extra wrapper process left in between.
-    """
-    os.execvp('ros2', ['ros2', 'run', 'joy', 'joy_node'])
 
 
 if __name__ == '__main__':

--- a/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
+++ b/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
@@ -20,6 +20,14 @@ Controls:
     r      — move to safe pose + start servo
     ESC/x  — exit
 
+Gamepad controls (via ros2 joy game_controller_node, e.g. Stadia controller):
+    Right stick      — forward/back, left/right  (X / Y axis)
+    Left stick       — yaw / pitch
+    L2 / R2          — roll
+    L2 / R2, Y held  — up / down
+    A                — move to safe pose + start servo
+    X                — exit
+
 Usage:
     Real hardware / RViz mock-hardware demo (wall clock, conservative speeds):
         ros2 run arm_tasks keyboard_servo_node
@@ -27,6 +35,10 @@ Usage:
     Gazebo sim (sim clock + faster speeds, see arm_sim/config/keyboard_servo_sim.yaml):
         ros2 run arm_tasks keyboard_servo_node --ros-args \\
             --params-file $(ros2 pkg prefix arm_sim)/share/arm_sim/config/keyboard_servo_sim.yaml
+
+    Gamepad, any target (start the joystick driver first, then this node):
+        ros2 run joy game_controller_node
+        ros2 run arm_tasks gamepad_servo_node
 """
 
 import sys
@@ -38,6 +50,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.action import ActionClient
 from geometry_msgs.msg import TwistStamped
+from sensor_msgs.msg import Joy
 from std_msgs.msg import Int8
 from std_srvs.srv import Trigger
 from action_msgs.msg import GoalStatus
@@ -627,22 +640,209 @@ class KeyboardInputLoop:
                 termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_term_settings)
 
 
-def main():
-    """Entry point: initialize ROS2, run the keyboard input loop, and clean up.
+GAMEPAD_HELP = """
+╔══════════════════════════════════════════════╗
+║      Gamepad Servo Control (camera frame)    ║
+╠══════════════════════════════════════════════╣
+║  Right stick      — forward / back (X)       ║
+║                     left / right   (Y)       ║
+║  Left stick       — yaw                      ║
+║                     pitch                    ║
+║  L2 / R2          — roll                     ║
+║  L2 / R2, Y held  — up / down      (Z)       ║
+║  A                — safe pose + servo        ║
+║  X                — exit                     ║
+╚══════════════════════════════════════════════╝
+"""
 
-    Initializes rclpy, creates the ``ServoController`` node, spins it in a
-    background daemon thread, then runs the blocking ``KeyboardInputLoop``
-    on the main thread. On exit (normal, via ESC/X, or ``KeyboardInterrupt``),
-    stops any motion, confirms Servo has stopped, destroys the node, and
-    shuts down rclpy.
+
+class GamepadInputLoop:
+    """Reads sensor_msgs/Joy messages and drives a ``ServoController``.
+
+    Replaces the raw-keyboard evdev input of ``KeyboardInputLoop`` with a
+    subscription to the ``joy`` package's ``/joy`` topic (published by
+    ``ros2 run joy game_controller_node``) — as this module's docstring
+    already promises, ``ServoController`` itself needs no changes.
+
+    Axis/button indices follow the standard SDL_GameController enum,
+    which ros2 joy's game_controller_node wraps directly — axes in the
+    order LEFTX, LEFTY, RIGHTX, RIGHTY, TRIGGERLEFT, TRIGGERRIGHT, and
+    buttons A, B, X, Y, BACK, GUIDE, START, LEFTSTICK, RIGHTSTICK, ...
+    This matches a live baseline read from a Stadia controller (6 axes,
+    20 buttons, all resting at 0), and axis 1 = left-stick-Y was
+    confirmed directly against hardware. The rest follow from the same
+    enum and are very likely correct, but confirm anything that doesn't
+    respond as expected via `ros2 topic echo /joy`.
     """
-    rclpy.init()
-    controller = ServoController()
 
+    AXIS_LEFT_X = 0     # yaw
+    AXIS_LEFT_Y = 1     # pitch
+    AXIS_RIGHT_X = 2    # left / right
+    AXIS_RIGHT_Y = 3    # forward / back
+    AXIS_L2 = 4         # roll (normal) / down (Y held) — negative half of the pair
+    AXIS_R2 = 5         # roll (normal) / up (Y held)   — positive half of the pair
+
+    BUTTON_SAFE_POSE = 0   # 'A' — move to safe pose + start servo
+    BUTTON_Y = 3           # 'Y' — held to shift L2 / R2 from roll to up / down
+    BUTTON_EXIT = 2        # 'X' — exit
+
+    _DEADZONE = 0.15
+
+    def __init__(self, controller: 'ServoController'):
+        """Store a reference to the controller and subscribe to ``/joy``.
+
+        Args:
+            controller: The ``ServoController`` node that will receive
+                velocity commands derived from gamepad input. Its own
+                ``create_subscription`` is reused for the ``/joy`` topic
+                so the callback runs on the node's existing executor —
+                no separate thread is needed, unlike the keyboard's
+                blocking evdev read loop.
+        """
+        self._controller = controller
+        self._linear_speed = controller.linear_speed
+        self._angular_speed = controller.angular_speed
+        self._exit_event = threading.Event()
+        self._prev_buttons = []
+        self._shift_armed = {self.BUTTON_Y: False}
+        self._safe_pose_running = threading.Lock()
+        self._prev_active = (False,) * 6
+        self._sub = controller.create_subscription(Joy, 'joy', self._on_joy, 10)
+
+    @classmethod
+    def _deadzone(cls, value: float) -> float:
+        """Zero out small stick values so resting drift doesn't creep the arm."""
+        return 0.0 if abs(value) < cls._DEADZONE else value
+
+    def _axis(self, axes, index: int) -> float:
+        """Return ``axes[index]`` with deadzone applied, or 0.0 if out of range."""
+        if index >= len(axes):
+            return 0.0
+        return self._deadzone(axes[index])
+
+    def _button_pressed(self, buttons, index: int) -> bool:
+        """Return True if ``buttons[index]`` is currently held down."""
+        return index < len(buttons) and buttons[index] == 1
+
+    def _button_rising_edge(self, buttons, index: int) -> bool:
+        """Return True if ``buttons[index]`` was just pressed this message."""
+        was_pressed = index < len(self._prev_buttons) and self._prev_buttons[index] == 1
+        return self._button_pressed(buttons, index) and not was_pressed
+
+    def _route(self, shift_button: int, held: bool, raw_value: float):
+        """Route one combined trigger value to a (normal, shifted) pair.
+
+        While ``shift_button`` is not held, ``raw_value`` is returned as
+        ``(raw_value, 0.0)``. While held, it's routed to the second slot
+        instead — but only once ``raw_value`` has passed back through the
+        deadzone since the button was pressed (i.e. L2/R2 have been let
+        go back to neutral at least once since Y was pressed), returning
+        ``(0.0, 0.0)`` until then. This is what prevents an already-held
+        trigger from producing a velocity jump the instant Y is pressed.
+        Disarmed again as soon as ``shift_button`` is released.
+        """
+        if not held:
+            self._shift_armed[shift_button] = False
+            return raw_value, 0.0
+        if not self._shift_armed[shift_button]:
+            if raw_value == 0.0:
+                self._shift_armed[shift_button] = True
+            return 0.0, 0.0
+        return 0.0, raw_value
+
+    @staticmethod
+    def _active_label(vx, vy, vz, wx, wy, wz, y_held: bool) -> str:
+        """Describe which physical control(s) are driving a nonzero command.
+
+        Mirrors KeyboardInputLoop's per-key name in the feedback line,
+        generalized to gamepad axes (several of which can be active at
+        once, e.g. a diagonally-pushed stick).
+        """
+        parts = []
+        if vx or vy:
+            parts.append('right stick')
+        if wy or wz:
+            parts.append('left stick')
+        if wx:
+            parts.append('L2/R2')
+        if vz:
+            parts.append('Y+L2/R2')
+        return '+'.join(parts) if parts else ('Y' if y_held else 'idle')
+
+    def _on_joy(self, msg: Joy):
+        """Translate one Joy snapshot into a velocity command and edge-triggered actions."""
+        axes = msg.axes
+        buttons = msg.buttons
+
+        vy = self._axis(axes, self.AXIS_RIGHT_X) * self._linear_speed
+        vx = self._axis(axes, self.AXIS_RIGHT_Y) * self._linear_speed
+
+        wz = self._axis(axes, self.AXIS_LEFT_X) * self._angular_speed
+        wy = self._axis(axes, self.AXIS_LEFT_Y) * self._angular_speed
+
+        trigger_diff = self._axis(axes, self.AXIS_R2) - self._axis(axes, self.AXIS_L2)
+        y_held = self._button_pressed(buttons, self.BUTTON_Y)
+        roll, updown = self._route(self.BUTTON_Y, y_held, trigger_diff)
+        wx = roll * self._angular_speed
+        vz = updown * self._linear_speed
+
+        self._controller.set_velocity(vx, vy, vz, wx, wy, wz)
+
+        active = (vx != 0.0, vy != 0.0, vz != 0.0, wx != 0.0, wy != 0.0, wz != 0.0)
+        if active != self._prev_active and any(active):
+            label = self._active_label(vx, vy, vz, wx, wy, wz, y_held)
+            print(f'{label} vx={vx:.2f} vy={vy:.2f} vz={vz:.2f} '
+                  f'wx={wx:.2f} wy={wy:.2f} wz={wz:.2f}')
+        self._prev_active = active
+
+        if self._button_rising_edge(buttons, self.BUTTON_SAFE_POSE):
+            threading.Thread(target=self._handle_safe_pose, daemon=True).start()
+
+        if self._button_rising_edge(buttons, self.BUTTON_EXIT):
+            self._exit_event.set()
+
+        self._prev_buttons = list(buttons)
+
+    def _handle_safe_pose(self):
+        """Stop motion and move to the safe pose (mirrors KeyboardInputLoop's 'r').
+
+        Guarded by a non-blocking lock so a second button press while a
+        move is already in progress is ignored instead of racing a
+        redundant safe-pose goal against the first.
+        """
+        if not self._safe_pose_running.acquire(blocking=False):
+            return
+        try:
+            self._controller.stop()
+            print('Moving to safe pose...')
+            if self._controller.move_to_safe_pose():
+                print('Starting servo...')
+                self._controller.start_servo()
+            else:
+                print('Safe pose failed — Servo not started.')
+        finally:
+            self._safe_pose_running.release()
+
+    def run(self):
+        """Print the help banner and block until the exit button is pressed."""
+        print(GAMEPAD_HELP)
+        try:
+            self._exit_event.wait()
+        finally:
+            print('\nExiting...')
+            self._controller.stop()
+
+
+def _run_teleop(controller: 'ServoController', input_loop) -> None:
+    """Spin ``controller`` in a background thread and run ``input_loop`` until exit.
+
+    Shared by ``main`` (keyboard) and ``main_gamepad`` (gamepad): both
+    input loops expose the same ``run()`` contract (block until an exit
+    condition, leave the controller stopped), so the ROS lifecycle
+    around them doesn't need to be duplicated per input source.
+    """
     spin_thread = threading.Thread(target=rclpy.spin, args=(controller,), daemon=True)
     spin_thread.start()
-
-    input_loop = KeyboardInputLoop(controller)
 
     try:
         input_loop.run()
@@ -657,6 +857,28 @@ def main():
             )
         controller.destroy_node()
         rclpy.shutdown()
+
+
+def main():
+    """Entry point: initialize ROS2, run the keyboard input loop, and clean up.
+
+    See ``_run_teleop`` for the shared spin/cleanup lifecycle.
+    """
+    rclpy.init()
+    controller = ServoController()
+    _run_teleop(controller, KeyboardInputLoop(controller))
+
+
+def main_gamepad():
+    """Entry point: initialize ROS2, run the gamepad input loop, and clean up.
+
+    Requires a running ``joy`` publisher (``ros2 run joy
+    game_controller_node``). See ``_run_teleop`` for the shared
+    spin/cleanup lifecycle.
+    """
+    rclpy.init()
+    controller = ServoController()
+    _run_teleop(controller, GamepadInputLoop(controller))
 
 
 if __name__ == '__main__':

--- a/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
+++ b/src/arm/arm_tasks/arm_tasks/keyboard_servo_node.py
@@ -37,10 +37,16 @@ Usage:
             --params-file $(ros2 pkg prefix arm_sim)/share/arm_sim/config/keyboard_servo_sim.yaml
 
     Gamepad, any target (start the joystick driver first, then this node):
-        ros2 run joy game_controller_node
+        ros2 run arm_tasks gamepad_joy_driver
         ros2 run arm_tasks gamepad_servo_node
+
+    ``gamepad_joy_driver`` is a thin wrapper around ``ros2 run joy
+    game_controller_node`` — see ``main_gamepad_joy_driver`` below for
+    why a plain ``ros2 run joy game_controller_node`` isn't enough for
+    this specific controller over Bluetooth.
 """
 
+import os
 import sys
 import threading
 import termios
@@ -60,6 +66,29 @@ from builtin_interfaces.msg import Duration
 import evdev
 from evdev import ecodes
 
+
+# SDL's built-in mapping for this controller (GUID
+# 03000000d11800000094000011010000, name "Google Stadia Controller") only
+# matches it over USB. Over Bluetooth the same physical controller gets a
+# different GUID (05000000d11800000094000000010000 — same vendor/product,
+# different bus-type byte), which has no built-in entry, and SDL's
+# automatic fallback mapping for it is broken: confirmed live via a
+# standalone SDL2 test program dumping SDL_GameControllerMapping() that it
+# never maps rightx/righty at all, and instead assigns lefttrigger and
+# righttrigger to the right stick's raw axes (a2/a3). This override is
+# that same auto-generated mapping, corrected: rightx/righty restored on
+# their real raw axes, and the triggers moved to their real raw axes
+# (a4/a5, confirmed via `ros2 topic echo /joy` and raw evdev ABS values).
+# Harmless over USB, where the built-in mapping already wins for its own
+# (different) GUID.
+STADIA_BLUETOOTH_MAPPING = (
+    "05000000d11800000094000000010000,StadiaBFRY-fe89,"
+    "a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,"
+    "leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,"
+    "dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,"
+    "leftx:a0,lefty:a1,rightx:a2,righty:a3,"
+    "lefttrigger:a4,righttrigger:a5,platform:Linux"
+)
 
 DEFAULT_LINEAR_SPEED  = 0.1
 DEFAULT_ANGULAR_SPEED = 0.3
@@ -652,14 +681,6 @@ GAMEPAD_HELP = """
 ║  L2 / R2, Y held  — up / down      (Z)       ║
 ║  A                — safe pose + servo        ║
 ║  X                — exit                     ║
-╠══════════════════════════════════════════════╣
-║  Press A once at startup: sticks/triggers    ║
-║  are ignored until the safe-pose move        ║
-║  succeeds. After that, a /joy dropout (e.g.  ║
-║  Bluetooth reconnect) just pauses motion,    ║
-║  then auto-resumes from the current position ║
-║  as soon as a clean centered reading comes   ║
-║  in — no button, no trip back to safe pose.  ║
 ╚══════════════════════════════════════════════╝
 """
 
@@ -719,7 +740,15 @@ class GamepadInputLoop:
         self._linear_speed = controller.linear_speed
         self._angular_speed = controller.angular_speed
         self._exit_event = threading.Event()
-        self._prev_buttons = []
+        # None means "no trustworthy baseline yet" — the first message
+        # after startup or after a /joy dropout is used only to seed
+        # this, never to fire a rising-edge action. Buttons can read
+        # garbage on that first message just like axes do (observed
+        # live: X came back as "pressed" on reconnect with nobody
+        # touching it, immediately exiting gamepad_servo_node instead
+        # of being ignored like a real accidental press would need a
+        # real prior "not pressed" reading to compare against).
+        self._prev_buttons = None
         self._shift_armed = {self.BUTTON_Y: False}
         self._safe_pose_running = threading.Lock()
         self._safe_pose_active = False
@@ -772,7 +801,14 @@ class GamepadInputLoop:
         return index < len(buttons) and buttons[index] == 1
 
     def _button_rising_edge(self, buttons, index: int) -> bool:
-        """Return True if ``buttons[index]`` was just pressed this message."""
+        """Return True if ``buttons[index]`` was just pressed this message.
+
+        Requires a real previous reading — see ``_prev_buttons`` in
+        ``__init__`` for why ``None`` (no baseline yet) always reports
+        no edge rather than comparing against an assumed all-zero state.
+        """
+        if self._prev_buttons is None:
+            return False
         was_pressed = index < len(self._prev_buttons) and self._prev_buttons[index] == 1
         return self._button_pressed(buttons, index) and not was_pressed
 
@@ -836,6 +872,7 @@ class GamepadInputLoop:
             if not self._joy_silent:
                 self._joy_silent = True
                 self._joy_settling = True
+                self._prev_buttons = None
                 self._controller.get_logger().warn(
                     f'/joy timed out after {elapsed:.2f}s — stopping arm.'
                 )
@@ -987,13 +1024,34 @@ def main():
 def main_gamepad():
     """Entry point: initialize ROS2, run the gamepad input loop, and clean up.
 
-    Requires a running ``joy`` publisher (``ros2 run joy
-    game_controller_node``). See ``_run_teleop`` for the shared
-    spin/cleanup lifecycle.
+    Requires a running ``joy`` publisher — use ``gamepad_joy_driver``
+    (below), not a plain ``ros2 run joy game_controller_node``, or the
+    Bluetooth axis mapping fix won't be applied. See ``_run_teleop`` for
+    the shared spin/cleanup lifecycle.
     """
     rclpy.init()
     controller = ServoController()
     _run_teleop(controller, GamepadInputLoop(controller))
+
+
+def main_gamepad_joy_driver():
+    """Entry point: run ``joy``'s ``game_controller_node`` with a fixed
+    Bluetooth mapping for the Stadia controller.
+
+    A drop-in replacement for ``ros2 run joy game_controller_node`` —
+    sets ``SDL_GAMECONTROLLERCONFIG`` (see ``STADIA_BLUETOOTH_MAPPING``)
+    before exec'ing the real node, so the override is always in effect
+    without the operator having to remember to export it by hand each
+    time (it only lives for the lifetime of the process it's exported
+    into, so a plain ``ros2 run joy game_controller_node`` picks up
+    SDL's broken auto-generated Bluetooth mapping again every time).
+    Uses ``os.execvp`` rather than a subprocess so this process directly
+    becomes ``game_controller_node`` — signals (e.g. Ctrl+C) and process
+    lifetime behave exactly as if it had been started directly, with no
+    extra wrapper process left in between.
+    """
+    os.environ['SDL_GAMECONTROLLERCONFIG'] = STADIA_BLUETOOTH_MAPPING
+    os.execvp('ros2', ['ros2', 'run', 'joy', 'game_controller_node'])
 
 
 if __name__ == '__main__':

--- a/src/arm/arm_tasks/package.xml
+++ b/src/arm/arm_tasks/package.xml
@@ -26,6 +26,7 @@
 <exec_depend>arm_description</exec_depend>
 
 <exec_depend>python3-evdev</exec_depend>
+<exec_depend>joy</exec_depend>
 
 <test_depend>ament_copyright</test_depend>
 <test_depend>ament_flake8</test_depend>

--- a/src/arm/arm_tasks/setup.py
+++ b/src/arm/arm_tasks/setup.py
@@ -22,6 +22,7 @@ setup(
         'console_scripts': [
             'keyboard_servo_node = arm_tasks.keyboard_servo_node:main',
             'gamepad_servo_node = arm_tasks.keyboard_servo_node:main_gamepad',
+            'gamepad_joy_driver = arm_tasks.keyboard_servo_node:main_gamepad_joy_driver',
         ],
     },
 )

--- a/src/arm/arm_tasks/setup.py
+++ b/src/arm/arm_tasks/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'keyboard_servo_node = arm_tasks.keyboard_servo_node:main',
+            'gamepad_servo_node = arm_tasks.keyboard_servo_node:main_gamepad',
         ],
     },
 )

--- a/src/arm/arm_tasks/setup.py
+++ b/src/arm/arm_tasks/setup.py
@@ -22,7 +22,6 @@ setup(
         'console_scripts': [
             'keyboard_servo_node = arm_tasks.keyboard_servo_node:main',
             'gamepad_servo_node = arm_tasks.keyboard_servo_node:main_gamepad',
-            'gamepad_joy_driver = arm_tasks.keyboard_servo_node:main_gamepad_joy_driver',
         ],
     },
 )


### PR DESCRIPTION
## Description

Adds gamepad teleop for the arm as an alternative to keyboard control,
and hardens it for real hardware use. `ServoController` (the shared
node powering Cartesian velocity commands and the safe-pose action) is
unchanged — a new `GamepadInputLoop` class subscribes to `/joy`
(published by `ros2 joy`'s `joy_node`) instead of reading raw keyboard
events, exactly as the module's docstring already said this
integration should work.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Configuration change

## Changes Made

- `GamepadInputLoop`: right stick → forward/back + left/right, left stick → yaw/pitch, L2/R2 → roll, holding **Y** shifts L2/R2 to
  up/down instead, **A** → move to safe pose + start servo, **X** → exit
- Anti-jump guard on the L2/R2 shift: if the triggers are already off-center when Y is pressed, the shifted axis stays at 0 until they
  pass back through center once — switching modes never causes a sudden velocity jump
- Live feedback printed on control-state transitions (which stick/trigger is active + resulting vx..wz), mirroring `KeyboardInputLoop`'s key-down print
- **`/joy` watchdog**: a timer independent of message arrival stops the arm if no `Joy` message has been received for 0.2s, since `ServoController` otherwise keeps republishing the last commanded twist forever if the controller disconnects
- **Safe-pose input lock**: stick/trigger input is ignored while a safe-pose move is in progress, so a held stick can't resume Cartesian motion the instant Servo restarts
- One-time arm gate: teleop stays locked out until the first safe-pose move succeeds (Servo isn't started before that anyway); a later `/joy` dropout does **not** re-lock it or force another trip to the safe pose — control resumes from wherever the arm already is, gated only by requiring one genuinely centered reading before trusting axes again (protects against known BLE reconnect glitches where stale/garbage values are reported before the first real update)
- Button presses are only recognized as edges against a real prior reading — the first message after startup or a reconnect is used solely to establish a baseline, since a gamepad can report a stale "pressed" button on that first message (was causing spurious exits)
- Uses `ros2 joy`'s `joy_node` rather than `game_controller_node`: `game_controller_node` goes through SDL, which has no built-in axis mapping for this controller's Bluetooth identity and falls back to an auto-generated one that's broken (right stick unmapped, triggers pointed at the wrong axes). `joy_node` reads the kernel's already-calibrated joystick device directly, sidestepping that whole class of bug — no hardcoded mapping needed
- Trigger axes (L2/R2) rest at +1.0 and go to -1.0 at full press under `joy_node` (opposite convention from the sticks); `_trigger_amount()` normalizes that back to "0 at rest" so deadzone, the settle-guard, and the Y-shift logic don't need to special-case them
- Deadzone raised from 0.15 to 0.2
- `KeyboardInputLoop`: direction keys are now ignored entirely until Servo has actually started — pressing them earlier couldn't move the arm anyway, and `_handle_safe_pose` discards any accumulated key state regardless
- New `gamepad_servo_node` console entry point; `joy` added to `arm_tasks/package.xml`
- Reuses `ServoController` unchanged, so all existing behavior carries over automatically: safe-pose result verification + timeout, hardware vs. sim speed defaults via the existing `arm_sim/config/keyboard_servo_sim.yaml` params file

## Testing

- [x] I have tested this locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

### How to Test

1. `colcon build --symlink-install && source install/setup.bash`
2. `ros2 run joy joy_node` (confirm it logs `Opened joystick: ...`)
3. `ros2 run arm_tasks gamepad_servo_node` (or add `--ros-args --params-file $(ros2 pkg prefix arm_sim)/share/arm_sim/config/keyboard_servo_sim.yaml` for Gazebo sim time + faster speeds)
4. Move each stick, hold Y while moving L2/R2, press A (safe pose + servo start) and X (exit); watch the printed feedback line match what you're doing
5. Confirm sticks/triggers are ignored until A is pressed, and again during a safe-pose move
6. Disconnect/reconnect the controller mid-session and confirm the arm stops on disconnect and only resumes once a clean, centered reading comes through (all sticks at 0, both triggers released) — no phantom motion
7. To find/confirm axis and button indices for a specific controller: `ros2 topic echo /joy` while moving each control one at a time